### PR TITLE
Add empty exit function

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -50,3 +50,7 @@ process.cwd = function () { return '/' };
 process.chdir = function (dir) {
     throw new Error('process.chdir is not supported');
 };
+
+process.exit = function () {
+    // nothing to exit.
+};


### PR DESCRIPTION
Came across this when trying to run node unit tests with Browserify.
