### PR TITLE
Adjusted ev.source check for to accept null for Firefox extensions

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -16,7 +16,8 @@ process.nextTick = (function () {
     if (canPost) {
         var queue = [];
         window.addEventListener('message', function (ev) {
-            if (ev.source === window && ev.data === 'process-tick') {
+            var source = ev.source;
+            if ((source === window || source === null) && ev.data === 'process-tick') {
                 ev.stopPropagation();
                 if (queue.length > 0) {
                     var fn = queue.shift();


### PR DESCRIPTION
This pull request adds a tolerance check for `ev.source === null` as is present in Firefox extensions. For more information, please refer to #2.
