### PR TITLE
browserify key breaks in latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "url": "git://github.com/shtylman/node-process.git"
   },
   "browser": "./browser.js",
-  "browserify": "./browser.js",
   "main": "./index.js",
   "engines": {
     "node": ">= 0.6.0"


### PR DESCRIPTION
browserify now assumes the browserify key points at a transform
