### PR TITLE
Provide faster alternative for setImmediate with MutationObserver.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -77,7 +77,7 @@ process.emit = noop;
 
 process.binding = function (name) {
     throw new Error('process.binding is not supported');
-}
+};
 
 // TODO(shtylman)
 process.cwd = function () { return '/' };


### PR DESCRIPTION
I noticed some faster ways are available to do this. Since the browser vendors aren't to excited to add a `setImmediate` method, it needs a good alternative.

Performance this test: http://jsperf.com/setimmediate-test/14
Browser support: http://caniuse.com/#feat=mutationobserver

Not my code, just copied it from the jsperf and did some small readability improvements.

Discussion of the Chrome team: https://code.google.com/p/chromium/issues/detail?id=146172
Discussion of the Mozilla team: https://bugzilla.mozilla.org/show_bug.cgi?id=686201
