### PR TITLE
Provide faster alternative for setImmediate with MutationObserver.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -5,6 +5,8 @@ var process = module.exports = {};
 process.nextTick = (function () {
     var canSetImmediate = typeof window !== 'undefined'
     && window.setImmediate;
+    var canMutationObserver = typeof window !== 'undefined'
+    && window.MutationObserver;
     var canPost = typeof window !== 'undefined'
     && window.postMessage && window.addEventListener
     ;
@@ -13,8 +15,29 @@ process.nextTick = (function () {
         return function (f) { return window.setImmediate(f) };
     }
 
+    var queue = [];
+
+    if (canMutationObserver) {
+        var hiddenDiv = document.createElement("div");
+        var observer = new MutationObserver(function () {
+            var queueList = queue.slice();
+            queue.length = 0;
+            queueList.forEach(function (fn) {
+                fn();
+            });
+        });
+
+        observer.observe(hiddenDiv, { attributes: true });
+
+        return function nextTick(fn) {
+            if (!queue.length) {
+                hiddenDiv.setAttribute('yes', 'no');
+            }
+            queue.push(fn);
+        };
+    }
+
     if (canPost) {
-        var queue = [];
         window.addEventListener('message', function (ev) {
             var source = ev.source;
             if ((source === window || source === null) && ev.data === 'process-tick') {
@@ -54,7 +77,7 @@ process.emit = noop;
 
 process.binding = function (name) {
     throw new Error('process.binding is not supported');
-}
+};
 
 // TODO(shtylman)
 process.cwd = function () { return '/' };


### PR DESCRIPTION
I noticed some faster ways are available to do this. Since the browser vendors aren't to excited to add a setImmediate method, it needs a good alternative.

Performance this test: http://jsperf.com/setimmediate-test/14
Browser support: http://caniuse.com/#feat=mutationobserver

Not my code, just copied it from the jsperf and did some small readability improvements.

Discussion of the Chrome team: https://code.google.com/p/chromium/issues/detail?id=146172
Discussion of the Mozilla team: https://bugzilla.mozilla.org/show_bug.cgi?id=686201
