### PR TITLE
Add a trivial process.umask() implementation that returns 0.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -84,3 +84,4 @@ process.cwd = function () { return '/' };
 process.chdir = function (dir) {
     throw new Error('process.chdir is not supported');
 };
+process.umask = function() { return 0; };


### PR DESCRIPTION
I happened to need this method because I'm browserifying mkdirp, which happens to [use `process.umask()`](https://github.com/substack/node-mkdirp/blob/b98bedf92798ed73c87413eaf413d01dbe094a09/index.js#L19), along with [fake-fs](https://github.com/eldargab/node-fake-fs).
