### PR TITLE
Makes setImmediate consistent with other returned functions.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -12,7 +12,7 @@ process.nextTick = (function () {
     ;
 
     if (canSetImmediate) {
-        return function (f) { return window.setImmediate(f) };
+        return function (f) { window.setImmediate(f) };
     }
 
     var queue = [];


### PR DESCRIPTION
`process.nextTick` returns undefined for most browsers, but for IE10+ which use `setImmediate`, it returns the immediateId, which can lead to problems. This makes the api consistent.
