### PR TITLE
process.stdout.write and process.stderr.write

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -85,3 +85,50 @@ process.chdir = function (dir) {
     throw new Error('process.chdir is not supported');
 };
 process.umask = function() { return 0; };
+
+/**
+ * Return a buffered 'write' function.
+ * @param  {Function} printProxy Writes new lines to some output display.
+ * @return {Function}
+ */
+function newStreamWriteShim(printProxy){
+    var buffer = [],
+        npos = 0; // next position
+
+    /**
+     * Use 'printProxy' to print 'str'.
+     * Use 'printProxy' when a new line is detected. Until then, store strings
+     * in 'buffer'.
+     * @param  {String} str The string to print
+     * @param  {Sting} enc **ignored**
+     * @param  {Function} cb Called asyncly
+     * @return {Boolean} Always returns 'true'
+     */
+    function _writeShim(str, enc, cb){
+        cb = cb || enc || noop;
+        if ('function' !== typeof cb) cb = noop;
+
+        var c, i = 0;
+        while ( (c = str[i++]) ){
+            if ('\n' === c){
+                printProxy(buffer.join(''));
+                buffer.length = npos = 0;
+            } else if ('\b' === c){
+                npos--;
+            } else if ('\r' === c){
+                npos = 0;
+            } else {
+                buffer[npos++] = c;
+            }
+        }
+
+        process.nextTick(cb);
+
+        return true;
+    }
+
+    return _writeShim;
+}
+
+process.stdout = { write: newStreamWriteShim(console.log.bind(console)) };
+process.stderr = { write: newStreamWriteShim(console.error.bind(console)) };


### PR DESCRIPTION
**tl;dr:** I realize you want to keep this module small. Feel free to reject this PR; in which case I'll maintain my own shim.

This PR adds `write` methods to `process.stdout` / `process.stderr` which simulate the corresponding methods in Node.

The new `write` methods:
1. Simulate printing without a new line
2. Can handle control chars (`‘\r’`, `‘\b’`, `‘\n’`)
3. Use `console.log` / `console.error` as proxies for `stdout.write` / `stderr.write`

**Example:**

``` Javascript
process.stdout.write("hello");
process.stdout.write("world\n");
process.stdout.write("foo");
process.stdout.write("\rbar\bz\n");
```

Will print (exactly as in Node):

```
helloworld
baz
```

While doing the same with `console.log` will print:

```
hello
world

foo
barz

```

**Note:**

Prints are buffered until a `'\n'` char is encountered. So `process.stdout.write('foo')` will print nothing.
