### PR TITLE
Speed up nextTick in web workers

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -3,30 +3,33 @@
 var process = module.exports = {};
 
 process.nextTick = (function () {
-    var canSetImmediate = typeof window !== 'undefined'
-    && window.setImmediate;
+    var setImmediate = global.setImmediate || global.msSetImmediate;
     var canMutationObserver = typeof window !== 'undefined'
     && window.MutationObserver;
     var canPost = typeof window !== 'undefined'
-    && window.postMessage && window.addEventListener
-    ;
+    && window.postMessage && window.addEventListener;
 
-    if (canSetImmediate) {
-        return function (f) { return window.setImmediate(f) };
+    // use native setImmediate if available
+    if (setImmediate) {
+        return function nextTick(f) {
+            return setImmediate(f)
+        };
     }
 
     var queue = [];
-
+    function runQueue() {
+        if (!queue.length) return;
+        var queueList = queue.slice();
+        queue.length = 0;
+        queueList.forEach(function(fn) {
+            fn();
+        });
+    }    
+    
+    // mutation observers are the fastest method on the main thread
     if (canMutationObserver) {
         var hiddenDiv = document.createElement("div");
-        var observer = new MutationObserver(function () {
-            var queueList = queue.slice();
-            queue.length = 0;
-            queueList.forEach(function (fn) {
-                fn();
-            });
-        });
-
+        var observer = new MutationObserver(runQueue);
         observer.observe(hiddenDiv, { attributes: true });
 
         return function nextTick(fn) {
@@ -36,25 +39,64 @@ process.nextTick = (function () {
             queue.push(fn);
         };
     }
+    
+    // fastest available method in Workers in Chrome
+    if (typeof Object.observe === 'function') {
+        var obj = { key: 0 };
+        Object.observe(obj, runQueue);
+        
+        return function nextTick(fn) {
+            if (!queue.length) {
+                obj.key++;
+            }
+            queue.push(fn);
+        };
+    }
+    
+    // next fastest method for workers: native promises. 
+    // supported by Firefox, and Safari 8+
+    if (typeof Promise !== 'undefined') {
+        return function(fn) {
+            if (!queue.length) {
+                Promise.resolve().then(runQueue);
+            }
+            queue.push(fn);
+        }
+    }
+    
+    // final method for workers: message channel
+    // supported by older Chrome and Safari
+    if (typeof MessageChannel !== 'undefined') {
+        var channel = new MessageChannel();
+        channel.port1.onmessage = runQueue;
 
+        return function nextTick(fn) {
+            if (!queue.length) {
+                channel.port2.postMessage('tick');
+            }
+            queue.push(fn);
+        };
+    }
+    
+    // On the main thread, postMessage is fast if mutation observers aren't available
     if (canPost) {
         window.addEventListener('message', function (ev) {
             var source = ev.source;
             if ((source === window || source === null) && ev.data === 'process-tick') {
                 ev.stopPropagation();
-                if (queue.length > 0) {
-                    var fn = queue.shift();
-                    fn();
-                }
+                runQueue();
             }
         }, true);
 
         return function nextTick(fn) {
+            if (!queue.length) {
+                window.postMessage('process-tick', '*');
+            }
             queue.push(fn);
-            window.postMessage('process-tick', '*');
         };
     }
 
+    // Otherwise, fall back to setTimeout
     return function nextTick(fn) {
         setTimeout(fn, 0);
     };


### PR DESCRIPTION
I've been working on some streaming image processing, and I was debugging why it was running 10 times slower in web workers than on the main thread. I did some profiling and saw lots of what looked like idle time. After a few days I figured it out: the node stream module calls process.nextTick a lot and it was falling back to `setTimeout` inside web workers since mutation observers and postMessage are not supported there.

This PR adds three async yielding methods that are supported by workers in various browsers, in order of speed according to http://jsperf.com/setimmediate-test/17. They are: `Object.observe` (fastest by far in Chrome), native `Promise` (fastest in Firefox and new Safari), and `MessageChannel` (old Chrome and Safari).
