### PR TITLE
fixes #26

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -40,8 +40,13 @@ process.nextTick = (function () {
     if (canPost) {
         window.addEventListener('message', function (ev) {
             var source = ev.source;
-            if ((source === window || source === null) && ev.data === 'process-tick') {
-                ev.stopPropagation();
+            if ((source == window || source === null) && ev.data === 'process-tick') {
+                if (typeof ev.stopPropagation === 'function') {
+                    ev.stopPropagation();
+                }
+                else {
+                    ev.cancelBubble = true;
+                }
                 if (queue.length > 0) {
                     var fn = queue.shift();
                     fn();


### PR DESCRIPTION
FIxes Issue #26

Changes:
- event.stopPropagation doesn't exist in IE8, use cancelBubble instead
- event.source is not === window in IE8, use == instead
