### PR TITLE
nextTick based on microtask queue

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -12,7 +12,9 @@ process.nextTick = (function() {
             return function() {
                 resolvedPromise.then(drainQueue);
             };
-        } else if('function' === typeof Object.observe) {
+        }
+
+        if('function' === typeof Object.observe) {
             var obj = { prop: 1 };
 
             Object.observe(obj, drainQueue);
@@ -20,11 +22,11 @@ process.nextTick = (function() {
             return function() {
                 obj.prop = -obj.prop;
             };
-        } else {
-            return function() {
-                setTimeout(drainQueue, 0);
-            };
         }
+        
+        return function() {
+            setTimeout(drainQueue, 0);
+        };
     })();
 
     function drainQueue() {

--- a/browser.js
+++ b/browser.js
@@ -1,33 +1,59 @@
 // shim for using process in browser
 
 var process = module.exports = {};
-var queue = [];
-var draining = false;
 
-function drainQueue() {
-    if (draining) {
-        return;
-    }
-    draining = true;
-    var currentQueue;
-    var len = queue.length;
-    while(len) {
-        currentQueue = queue;
-        queue = [];
-        var i = -1;
-        while (++i < len) {
-            currentQueue[i]();
+process.nextTick = (function() {
+    var queue = [];
+    var draining = false;
+    var scheduleDraining = (function() {
+        if(('undefined' !== typeof Promise) && ('function' === typeof Promise.resolve)) {
+            var resolvedPromise = Promise.resolve();
+
+            return function() {
+                resolvedPromise.then(drainQueue);
+            };
+        } else if('function' === typeof Object.observe) {
+            var obj = { prop: 1 };
+
+            Object.observe(obj, drainQueue);
+
+            return function() {
+                obj.prop = -obj.prop;
+            };
+        } else {
+            return function() {
+                setTimeout(drainQueue, 0);
+            };
         }
-        len = queue.length;
+    })();
+
+    function drainQueue() {
+        if (draining) {
+            return;
+        }
+        draining = true;
+        var currentQueue;
+        var len = queue.length;
+        while(len) {
+            currentQueue = queue;
+            queue = [];
+            var i = -1;
+            while (++i < len) {
+                currentQueue[i]();
+            }
+            len = queue.length;
+        }
+        draining = false;
     }
-    draining = false;
-}
-process.nextTick = function (fun) {
-    queue.push(fun);
-    if (!draining) {
-        setTimeout(drainQueue, 0);
-    }
-};
+
+
+    return function nextTick(fun) {
+        queue.push(fun);
+        if (!draining) {
+            scheduleDraining();
+        }
+    };
+})();
 
 process.title = 'browser';
 process.browser = true;


### PR DESCRIPTION
I've just read Miller's Medeiros post about nextTick implementation based on native Promise.prototype.then method. It's not only faster than approach based on setTimeout and queue, but what is more important, it corresponds better with native node's implementation - it uses microtask queue, which is drained after each event loop "part" (I can't find better word for it), not once per iteration as timeout queue is. Here are resources (thank you so much @mthenw!): 
- http://blog.millermedeiros.com/promise-nexttick/
- http://i.imgur.com/V25fwf9.jpg
- https://gist.github.com/mthenw/7114d5e79d2cbd680093
- http://jsperf.com/asyncstuff/4

What do you think?

