### PR TITLE
Handle nextTick task errors

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -16,7 +16,13 @@ function drainQueue() {
         queue = [];
         var i = -1;
         while (++i < len) {
-            currentQueue[i]();
+            try {
+                currentQueue[i]();
+            } catch(e) {
+                setTimeout(function() {
+                    throw e;
+                },0);
+            }
         }
         len = queue.length;
     }


### PR DESCRIPTION
When draining the nextTick task queue, if there is a single task error, it is thrown and stop immediately the draining of the queue.
Also it leaves the attribute `draining = true`, making subsequent calls to nextTick not trigger the draining again)

I think the draining should complete for all queued tasks, and errors on single tasks should not stop the other queued tasks to execute.

I choose to handle exceptions in a setTimeout as it seems to be more natural than using a logger. As exceptions are "exceptional" this should probably not be a big performance problem.


This solves serious issues that appeared with nextTick, with Browserify >= 8.1.0 (for example with the Q promise library).

See:
https://github.com/kriskowal/q/issues/669
https://github.com/substack/node-browserify/issues/1179