### PR TITLE
errors and schedualling

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "keywords": [
     "process"
   ],
+  "scripts": {
+    "test": "mocha test.js"
+  },
   "version": "0.10.1",
   "repository": {
     "type": "git",
@@ -14,5 +17,8 @@
   "main": "./index.js",
   "engines": {
     "node": ">= 0.6.0"
+  },
+  "devDependencies": {
+    "mocha": "2.2.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,29 @@
+var ourProcess = require('./browser');
+var assert = require('assert');
+
+describe('test errors', function (t) {
+    it ('works', function (done) {
+    var order = 0;
+    process.removeAllListeners('uncaughtException');
+    process.once('uncaughtException', function(err) {
+        assert.equal(2, order++, 'error is third');
+        process.nextTick(function () {
+            assert.equal(5, order++, 'schedualed in error is last');
+            done();
+        });
+    });
+    process.nextTick(function () {
+        assert.equal(0, order++, 'first one works');
+        process.nextTick(function () {
+        assert.equal(4, order++, 'recursive one is 4th');
+        });
+    });
+    process.nextTick(function () {
+        assert.equal(1, order++, 'second one starts');
+        throw(new Error('an error is thrown'));
+    });
+    process.nextTick(function () {
+        assert.equal(3, order++, '3rd schedualed happens after the error');
+    });
+    });
+});


### PR DESCRIPTION
slightly more complete solution to #37 with tests!

Errors are not rethrown so it will still show up as an uncaught error when used with a debuger also a try/catch is avoided which can be slow in certain browsers