### PR TITLE
Add platform to avoid emscripten code failure under browserify

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -34,6 +34,7 @@ process.browser = true;
 process.env = {};
 process.argv = [];
 process.version = ''; // empty string to avoid regexp issues
+process.platform = ''; // same as above
 process.versions = {};
 
 function noop() {}


### PR DESCRIPTION
Trying to run browserified emscripten code, I get an error because emscripten attempts to call process.platform.match.

I figured this could be an issue with more `process`-using stuff.