### PR TITLE
Mention `process.browser` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Works in node.js and browsers via the browser.js shim provided with the module.
 
 ## browser implementation
 
-The goal of this module is not to be a full-fledged alternative to the builtin process module. This module mostly exists to provide the nextTick functionality and nothing more. We keep this module lean because it will often be included by default by tools like browserify when it detects a module has used the `process` global.
+The goal of this module is not to be a full-fledged alternative to the builtin process module. This module mostly exists to provide the nextTick functionality. We keep this module lean because it will often be included by default by tools like browserify when it detects a module has used the `process` global.
+
+It also exposes a "browser" member (i.e. `process.browser`) which is `true` in the browser implementation but `undefined` in node. This can be used to achieve isomorphic code that adjusts it's behavior depending on which environment it's being run in. 
 
 If you are looking to provide other process methods, I suggest you monkey patch them onto the process global in your app. A list of user created patches is below.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Works in node.js and browsers via the browser.js shim provided with the module.
 
 ## browser implementation
 
-The goal of this module is not to be a full-fledged alternative to the builtin process module. This module mostly exists to provide the nextTick functionality. We keep this module lean because it will often be included by default by tools like browserify when it detects a module has used the `process` global.
+The goal of this module is not to be a full-fledged alternative to the builtin process module. This module mostly exists to provide the nextTick functionality and little more. We keep this module lean because it will often be included by default by tools like browserify when it detects a module has used the `process` global.
 
-It also exposes a "browser" member (i.e. `process.browser`) which is `true` in the browser implementation but `undefined` in node. This can be used to achieve isomorphic code that adjusts it's behavior depending on which environment it's being run in. 
+It also exposes a "browser" member (i.e. `process.browser`) which is `true` in this implementation but `undefined` in node. This can be used in isomorphic code that adjusts it's behavior depending on which environment it's running in. 
 
 If you are looking to provide other process methods, I suggest you monkey patch them onto the process global in your app. A list of user created patches is below.
 


### PR DESCRIPTION
This turned out to be a very important feature to me.

For isomorphic apps, we frequently need to refer to whether our js is running in node or the browser. Knowing the shortest way to reference this has become a point for me. 

My first solution was to put `var on_client = typeof window=='object';` around the top of all the modules that needed it, with the dependencies, but this seemed like an anti-pattern. 

I actually went to the extent of publishing an [on-client](https://www.npmjs.com/package/on-client) package for determining the environment, which i've now deprecated.

I also considered depending on [lodash](https://www.npmjs.com/package/lodash).support.dom and [lodash.support](https://www.npmjs.com/package/lodash.support).dom (also undocumented!)

And (since I'm using browserify) `process.browser` was there all along! lol