### PR TITLE
browser: cache setTimeout and clearTimeout to isolate from global

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,6 +1,11 @@
 // shim for using process in browser
 
 var process = module.exports = {};
+
+// cached from whatever global is present so that test runners that stub it don't break things.
+var cachedSetTimeout = setTimeout;
+var cachedClearTimeout = clearTimeout;
+
 var queue = [];
 var draining = false;
 var currentQueue;
@@ -25,7 +30,7 @@ function drainQueue() {
     if (draining) {
         return;
     }
-    var timeout = setTimeout(cleanUpNextTick);
+    var timeout = cachedSetTimeout(cleanUpNextTick);
     draining = true;
 
     var len = queue.length;
@@ -42,7 +47,7 @@ function drainQueue() {
     }
     currentQueue = null;
     draining = false;
-    clearTimeout(timeout);
+    cachedClearTimeout(timeout);
 }
 
 process.nextTick = function (fun) {
@@ -54,7 +59,7 @@ process.nextTick = function (fun) {
     }
     queue.push(new Item(fun, args));
     if (queue.length === 1 && !draining) {
-        setTimeout(drainQueue, 0);
+        cachedSetTimeout(drainQueue, 0);
     }
 };
 

--- a/test.js
+++ b/test.js
@@ -63,4 +63,26 @@ function test (ourProcess) {
         });
         });
     });
+
+    describe('rename globals', function (t) {
+      it('throws an error', function (done){
+        var oldTimeout = setTimeout;
+        setTimeout = function () {
+          setTimeout = oldTimeout;
+          assert.ok(false);
+          done();
+        }
+        var oldClear = clearTimeout;
+        clearTimeout = function () {
+          clearTimeout = oldClear;
+          assert.ok(false);
+          done();
+        }
+        ourProcess.nextTick(function () {
+          assert.ok(true);
+          setTimeout = oldTimeout;
+          done();
+        });
+      });
+    });
 }


### PR DESCRIPTION
tl;dr:
sinon stubs time related global objects for unit testing and this breaks all packages depended on _process.nextTick_. caching _setTimeout_ and _clearTimeout_ at bootstrap protects against mutations.

related issue:
https://github.com/sinonjs/lolex/issues/66