### PR TITLE
Calling cached methods as method

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -50,7 +50,7 @@ function drainQueue() {
     if (draining) {
         return;
     }
-    var timeout = cachedSetTimeout(cleanUpNextTick);
+    var timeout = cachedSetTimeout.call(this, cleanUpNextTick);
     draining = true;
 
     var len = queue.length;
@@ -67,7 +67,7 @@ function drainQueue() {
     }
     currentQueue = null;
     draining = false;
-    cachedClearTimeout(timeout);
+    cachedClearTimeout.call(this, timeout);
 }
 
 process.nextTick = function (fun) {
@@ -79,7 +79,7 @@ process.nextTick = function (fun) {
     }
     queue.push(new Item(fun, args));
     if (queue.length === 1 && !draining) {
-        cachedSetTimeout(drainQueue, 0);
+        cachedSetTimeout.call(this, drainQueue, 0);
     }
 };
 


### PR DESCRIPTION
In IE10 calling the cached setTimeout and clearTimeout causes an 'Invalid calling object' error. It needs to be called as a method in order to work.