### PR TITLE
node-process does not function in IE9

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -29,14 +29,14 @@ function runTimeout(fun) {
     if (cachedSetTimeout === setTimeout) {
         return setTimeout(fun, 0);
     } else {
-        return cachedSetTimeout.call(null, fun, 0);
+        return cachedSetTimeout(fun, 0);
     }
 }
 function runClearTimeout(marker) {
     if (cachedClearTimeout === clearTimeout) {
         clearTimeout(marker);
     } else {
-        cachedClearTimeout.call(null, marker);
+        cachedClearTimeout(marker);
     }
 }
 var queue = [];


### PR DESCRIPTION
This module seems to have recently become a dependency somewhere in the webpack toolchain (specifically as a sub-dependency of node-libs-browser). My team noticed a couple of days ago that a few of our build agents were generating client-side code that was no longer functional in IE9. (this may also be true of IE8 or lower, but we do not support them so it's hard to tell!)

We have tracked the issue down to the lines I've changed in this PR. Unfortunately in old versions of IE attempting to call ```setTimeout``` using ```.call(null,...)``` would fail with an error (```TypeError: Invalid calling object```), and prevent any further JS execution on the page. You can find more information about the error [here](https://msdn.microsoft.com/en-us/library/gg622930(v=vs.85).aspx), although this article unfortunately does not directly cover this particular scenario (```setTimeout``` and a ```null``` reference for ```this```).

Hope this PR meets your contribution requirements, and if this solution isn't acceptable or you want to discuss further I'd be happy to see what we can come up with :)