### PR TITLE
Add `toString` method

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -182,3 +182,4 @@ process.chdir = function (dir) {
     throw new Error('process.chdir is not supported');
 };
 process.umask = function() { return 0; };
+process.toString = function() { return "[object process]" };


### PR DESCRIPTION
In Node.js:
```js
process + "" // = "[object process]"
```

This patch just brings that behaviour over. I've seen this check in the wild (namely [here](https://github.com/zotero/zotero/blob/b99ee1f0308f6f12bbc1bc46e2a8d478e347c7ed/chrome/content/zotero/xpcom/utilities.js#L2028)).